### PR TITLE
add default value if List/project is missing in json

### DIFF
--- a/src/de/azapps/mirakel/model/task/Task.java
+++ b/src/de/azapps/mirakel/model/task/Task.java
@@ -787,6 +787,8 @@ public class Task extends TaskBase {
 				t.addAdditionalEntry(key, val.getAsString());
 			}
 		}
+        if (t.getList() == null)
+                t.setList(SpecialList.firstSpecial().getDefaultList());
 		return t;
 	}
 


### PR DESCRIPTION
taskwarrior coule create task whithout project, this could crash mirakel 
