### PR TITLE
Correct typo "intervall" to "interval" in lib_settings_strings.xml

### DIFF
--- a/settings/res/values/lib_settings_strings.xml
+++ b/settings/res/values/lib_settings_strings.xml
@@ -240,7 +240,7 @@ Soon the official DAVdroid app will also support Mirakel and we are working toge
     <string name="register_server">If you need an account for the sync on our server, please send us an e-mail. With the next version you\'ll get the possibility to register an account!</string>
     <string name="special_lists_title">Meta lists</string>
     <string name="register">Register</string>
-    <string name="auto_backup_intervall">Auto backup intervall</string>
+    <string name="auto_backup_intervall">Auto backup interval</string>
     <string name="auto_backup_intervall_summary">Backup the database every %s days</string>
 
     <!-- Colors -->


### PR DESCRIPTION
There are, in fact, many more misspellings of "interval" within the code, but this is the only user-facing instance I can find. I don't know if it's worth refactoring the entire code over that misspelling if it won't appear to the user anyway. I may decide to do that at a later point, but this is a "quick win".
