### PR TITLE
Get Mirakel to work with self-signed certificates. Should close MIR-622.

### DIFF
--- a/tw_sync/src/de/azapps/mirakel/sync/taskwarrior/network_helper/TLSClient.java
+++ b/tw_sync/src/de/azapps/mirakel/sync/taskwarrior/network_helper/TLSClient.java
@@ -64,7 +64,7 @@ public class TLSClient {
             }
             try {
                 certs.add((X509Certificate) CertificateFactory.getInstance("X.509")
-                          .generateCertificate(new StringBufferInputStream(part.trim() + "\n-----END CERTIFICATE-----")));
+                          .generateCertificate(new StringBufferInputStream(part.trim() + "-")));
             } catch (final CertificateException e) {
                 Log.wtf(TAG, "parsing failed:" + part, e);
                 return certs;


### PR DESCRIPTION
This alteration works with (the phone) Wiko Lenny, using Android 4.4.2

Could not test it on any other platform.