### PR TITLE
Use BufferedOutputStream

### DIFF
--- a/tw_sync/src/de/azapps/mirakel/sync/taskwarrior/network_helper/TLSClient.java
+++ b/tw_sync/src/de/azapps/mirakel/sync/taskwarrior/network_helper/TLSClient.java
@@ -26,6 +26,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.BufferedOutputStream;
 import java.io.StringBufferInputStream;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
@@ -345,7 +346,7 @@ public class TLSClient {
 
     // //////////////////////////////////////////////////////////////////////////////
     public void send(final String data) {
-        final DataOutputStream dos = new DataOutputStream(out);
+        final DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(out));
         if (!this._socket.isConnected()) {
             Log.e(TAG, "socket not connected");
             return;


### PR DESCRIPTION
fixes Taskwarrior sync problems on android 7
http://stackoverflow.com/questions/39439811/android-n-dataoutputstream-writeint-behaviour-changed
TW error: INFO expecting 0 bytes.